### PR TITLE
Add SendIndex for packet ordering and new callback with index

### DIFF
--- a/Packages/com.witalosk.rudp2p/Runtime/Packet.cs
+++ b/Packages/com.witalosk.rudp2p/Runtime/Packet.cs
@@ -5,40 +5,44 @@ namespace Rudp2p
     internal class Packet
     {
         public int PacketId { get; }
+        public int SendIndex { get; }
         public ushort SeqId { get; }
         public ushort TotalSeqNum { get; }
         public int Key { get; }
-        
-        public Packet(int packetId, ushort seqId, ushort totalSeqNum, int key)
+
+        public Packet(int packetId, int sendIndex, ushort seqId, ushort totalSeqNum, int key)
         {
             PacketId = packetId;
+            SendIndex = sendIndex;
             SeqId = seqId;
             TotalSeqNum = totalSeqNum;
             Key = key;
         }
-        
-        public const int HeaderSize = 12;
-        
-        public static void SetHeader(ref byte[] target, int packetId, ushort seqId, ushort totalSeqNum, int key)
+
+        public const int HeaderSize = 16;
+
+        public static void SetHeader(ref byte[] target, int packetId, int sendIndex, ushort seqId, ushort totalSeqNum, int key)
         {
             Buffer.BlockCopy(BitConverter.GetBytes(packetId), 0, target, 0, 4);
-            Buffer.BlockCopy(BitConverter.GetBytes(seqId), 0, target, 4, 2);
-            Buffer.BlockCopy(BitConverter.GetBytes(totalSeqNum), 0, target, 6, 2);
-            Buffer.BlockCopy(BitConverter.GetBytes(key), 0, target, 8, 4);
+            Buffer.BlockCopy(BitConverter.GetBytes(sendIndex), 0, target, 4, 4);
+            Buffer.BlockCopy(BitConverter.GetBytes(seqId), 0, target, 8, 2);
+            Buffer.BlockCopy(BitConverter.GetBytes(totalSeqNum), 0, target, 10, 2);
+            Buffer.BlockCopy(BitConverter.GetBytes(key), 0, target, 12, 4);
         }
         
         public static Packet GetHeader(in byte[] data)
         {
             int packetId = BitConverter.ToInt32(data, 0);
-            ushort seqId = BitConverter.ToUInt16(data, 4);
-            ushort totalSeqNum = BitConverter.ToUInt16(data, 6);
-            int key = BitConverter.ToInt32(data, 8);
-            return new Packet(packetId, seqId, totalSeqNum, key);
+            int sendIndex = BitConverter.ToInt32(data, 4);
+            ushort seqId = BitConverter.ToUInt16(data, 8);
+            ushort totalSeqNum = BitConverter.ToUInt16(data, 10);
+            int key = BitConverter.ToInt32(data, 12);
+            return new Packet(packetId, sendIndex, seqId, totalSeqNum, key);
         }
 
         public override string ToString()
         {
-            return $"PacketId: {PacketId}, SeqId: {SeqId}, TotalSeqNum: {TotalSeqNum}, Key: {Key}";
+            return $"PacketId: {PacketId}, SendIndex: {SendIndex}, SeqId: {SeqId}, TotalSeqNum: {TotalSeqNum}, Key: {Key}";
         }
     }
 }

--- a/Packages/com.witalosk.rudp2p/Runtime/ReliableSender.cs
+++ b/Packages/com.witalosk.rudp2p/Runtime/ReliableSender.cs
@@ -12,8 +12,8 @@ namespace Rudp2p
     {
         private readonly SendQueue _sendQueue = new(1250000, 625000);
         private readonly Dictionary<int, bool[]> _ackReceived = new();
-        
-        public async Task Send(UdpClient udp, IPEndPoint target, int key, byte[] data, int mtu = 1500, bool isReliable = true)
+
+        public async Task Send(UdpClient udp, IPEndPoint target, int key, byte[] data, int sendIndex, int mtu = 1500, bool isReliable = true)
         {
             if (data.Length > mtu * ushort.MaxValue - Packet.HeaderSize)
             {
@@ -32,7 +32,7 @@ namespace Rudp2p
                 int arraySize = size + Packet.HeaderSize;
                 
                 byte[] packet = ArrayPool<byte>.Shared.Rent(arraySize);
-                Packet.SetHeader(ref packet, packetId, (ushort)i, (ushort)totalPackets, key);
+                Packet.SetHeader(ref packet, packetId, sendIndex, (ushort)i, (ushort)totalPackets, key);
                 Buffer.BlockCopy(data, offset, packet, Packet.HeaderSize, size);
 
                 if (isReliable)


### PR DESCRIPTION
- Added SendIndex to outgoing packets

  - Enables packet ordering support over UDP

  - Each target gets a separate, incrementing index starting from 0

- Introduced callbackWithSendIndex

  - A new callback that includes the SendIndex along with the received data

  - Allows higher-level logic to handle ordering or deduplication if needed